### PR TITLE
mrc-6168 All countries dataset

### DIFF
--- a/config/grout.yml
+++ b/config/grout.yml
@@ -14,6 +14,20 @@ datasets:
     tiles:
       admin0:
         packit_server: reside
+        packet_id: 20250128-174650-f1147e76
+        download: level0.mbtiles
+      admin1:
+        packit_server: reside
+        packet_id: 20250128-174650-f1147e76
+        download: level1.mbtiles
+      admin2:
+        packit_server: reside
+        packet_id: 20250128-174650-f1147e76
+        download: level2.mbtiles
+  arbomap:
+    tiles:
+      admin0:
+        packit_server: reside
         packet_id: 20241214-195124-d22962c9
         download: level0.mbtiles
       admin1:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,11 +27,16 @@ def test_packit(cfg):
 
 
 def test_get_dataset_names(cfg):
-    assert cfg.datasets.get_dataset_names() == ["gadm41"]
+    assert cfg.datasets.get_dataset_names() == ["gadm41", "arbomap"]
 
 
 def test_get_dataset_tile_levels(cfg):
     assert cfg.datasets.get_dataset_tile_levels("gadm41") == [
+        "admin0",
+        "admin1",
+        "admin2",
+    ]
+    assert cfg.datasets.get_dataset_tile_levels("arbomap") == [
         "admin0",
         "admin1",
         "admin2",


### PR DESCRIPTION
This branch modifies the previous gadm41 dataset to be called "arbomap" (as it contains arbomap-only countries), and points a new "gadm41" dataset to the new grout data packet containing data from all countries. 

This branch is deployed on mrbdata, and metadata can be accessed here: https://mrcdata.dide.ic.ac.uk/grout/metadata